### PR TITLE
Create new Jest module

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -23,6 +23,7 @@
     "arenadotio",
     "npmrc",
     "pino",
-    "processid"
+    "processid",
+    "SRTE"
   ]
 }

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,2 +1,1 @@
---frozen-lockfile true
 --ignore-engines true

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ---
 
 <!-- AUTO-GENERATED-CONTENT:START (TOC) -->
+
 - [Install](#install)
 - [Usage](#usage)
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/fixtures/MockableStateReaderTaskEither.ts
+++ b/fixtures/MockableStateReaderTaskEither.ts
@@ -1,0 +1,9 @@
+import * as SRTE from 'fp-ts/lib/StateReaderTaskEither';
+import * as TE from 'fp-ts/lib/TaskEither';
+
+export const testFunction: SRTE.StateReaderTaskEither<
+  string,
+  number,
+  Error,
+  number
+> = (state) => (n) => TE.of([n * n, `${state}-${n}`]);

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,5 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['<rootDir>/tests/**/*.ts'],
-  setupFilesAfterEnv: ['@relmify/jest-fp-ts'],
+  setupFilesAfterEnv: ['./src/Jest.ts'],
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arena-fp-ts",
   "homepage": "https://github.com/arenadotio/arena-fp-ts",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "dist/index.js",
   "license": "MIT",
   "repository": {
@@ -37,13 +37,15 @@
     "logging-ts": "^0.3.4",
     "pino": "^8.14.1"
   },
-  "dependencies": {},
-  "devDependencies": {
+  "dependencies": {
     "@relmify/jest-fp-ts": "^2.1.1",
+    "jest-matcher-utils": "^29.6.1"
+  },
+  "devDependencies": {
     "@sentry/integrations": "^7.56.0",
     "@sentry/node": "^7.56.0",
     "@sentry/serverless": "^7.56.0",
-    "@types/jest": "^26.0.20",
+    "@types/jest": "^29.5.3",
     "@typescript-eslint/eslint-plugin": "^4.25.0",
     "@typescript-eslint/parser": "^4.25.0",
     "aws-lambda": "^1.0.7",
@@ -58,7 +60,7 @@
     "hot-shots": "^10.0.0",
     "io-ts": "^2.2.20",
     "io-ts-reporters": "^2.0.1",
-    "jest": "^29.5.0",
+    "jest": "^29.6.1",
     "jest-mock": "^29.5.0",
     "logging-ts": "^0.3.4",
     "markdown-magic": "^2.0.0",

--- a/src/Jest.ts
+++ b/src/Jest.ts
@@ -1,0 +1,322 @@
+/**
+ * In addition to the various types and utility functions, this module registers
+ * new matchers into Jest's `expect` module along with the matchers provided by
+ * `@relmify/jest-fp-ts`. Importing this module at the type of any test file
+ * will make these matchers available, but you can also add to your
+ * `jest.config.js`:
+ *
+ * ```
+ * module.exports = {
+ *   ...
+ *   setupFilesAfterEnv: ['arena-fp-ts/Jest'],
+ *   ...
+ * };
+ * ```
+ *
+ * @since 0.0.5
+ */
+import { matchers } from '@relmify/jest-fp-ts';
+
+import * as SRTE from 'fp-ts/lib/StateReaderTaskEither';
+import * as RTE from 'fp-ts/lib/ReaderTaskEither';
+import * as TE from 'fp-ts/lib/TaskEither';
+import * as A from 'fp-ts/lib/Array';
+import * as O from 'fp-ts/lib/Option';
+
+import { expect } from '@jest/globals';
+import { equals } from '@relmify/jest-fp-ts/dist/predicates/equals';
+import { isEitherOrThese } from '@relmify/jest-fp-ts/dist/predicates/isEitherOrThese';
+import {
+  EitherOrThese,
+  fold,
+  isRight,
+} from '@relmify/jest-fp-ts/dist/eitherOrThese/eitherOrThese';
+import { constFalse, flow, pipe } from 'fp-ts/lib/function';
+import {
+  matcherHint,
+  printDiffOrStringify,
+  printExpected,
+  printReceived,
+} from 'jest-matcher-utils';
+
+// -------------------------------------------------------------------------------------
+// model
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category models
+ * @since 0.0.5
+ */
+export type StateReaderTaskEitherPropertyNames<T> = {
+  [K in keyof T]: T[K] extends SRTE.StateReaderTaskEither<any, any, any, any>
+    ? K
+    : never;
+}[keyof T] &
+  string;
+
+// -------------------------------------------------------------------------------------
+// utils
+// -------------------------------------------------------------------------------------
+
+/**
+ * Spies on a StateReaderTaskEither and mocks the ReaderTaskEither that it
+ * returns.
+ *
+ * ```
+ * import { pipe } from 'fp-ts/lib/function';
+ * import * as TE from 'fp-ts/lib/TaskEither';
+ * import * as E from 'fp-ts/lib/Either';
+ * import { mockStateReaderTaskEither } from 'arena-fp-ts/Jest';
+ *
+ * import * as fakeModule from 'my-fake-module';
+ *
+ * describe(mockStateReaderTaskEither, () => {
+ *     it('can mock on StateReaderTaskEither return values', async () => {
+ *         const [spy] = mockStateReaderTaskEither(fakeModule, 'testFunction');
+ *         spy.mockReturnValue(TE.of([10, 'foo']));
+ *
+ *         const program = pipe(
+ *             1,
+ *             fakeModule.testFunction('some state'),
+ *         );
+ *         const result = await program();
+ *
+ *         expect(E.isRight(result) && result.right).toEqual([10, 'foo']);
+ *     });
+ *
+ *     it('can spy on reader arguments', async () => {
+ *         const [spy] = mockStateReaderTaskEither(fakeModule, 'testFunction');
+ *
+ *         const program = pipe(
+ *             1,
+ *             fakeModule.testFunction('some state'),
+ *         );
+ *         await program();
+ *
+ *         expect(spy).toHaveBeenCalledWith(1);
+ *     });
+ *
+ *     it('can spy on state arguments', async () => {
+ *         const [_, spy] = mockStateReaderTaskEither(fakeModule, 'testFunction');
+ *
+ *         const program = pipe(
+ *             1,
+ *             fakeModule.testFunction('some state'),
+ *         );
+ *         await program();
+ *
+ *         expect(spy).toHaveBeenCalledWith('some state');
+ *     });
+ * });
+ * ```
+ *
+ * @category utils
+ * @since 0.0.5
+ */
+export function mockStateReaderTaskEither<
+  S,
+  R,
+  E,
+  A,
+  T extends Record<string, unknown>,
+  M extends StateReaderTaskEitherPropertyNames<Required<T>>
+>(
+  object: T,
+  property: M
+): Required<T>[M] extends SRTE.StateReaderTaskEither<any, any, any, any>
+  ? [
+      jest.SpyInstance<TE.TaskEither<E, [A, S]>, [S]>,
+      jest.SpyInstance<RTE.ReaderTaskEither<R, E, [A, S]>, [S]>
+    ]
+  : never {
+  const fn = jest.fn(() => TE.of(undefined));
+
+  const spy = jest.spyOn(object, property as any);
+
+  spy.mockReturnValue(fn as any);
+
+  return [fn, spy] as any;
+}
+
+// -------------------------------------------------------------------------------------
+// Jest matchers
+// -------------------------------------------------------------------------------------
+
+/** @internal */
+const applyPredicateRightTuple =
+  (accessor: (as: unknown[]) => O.Option<unknown>) =>
+  (predicate: (rightResultValue: unknown) => boolean) =>
+  (received: EitherOrThese<unknown, unknown>): boolean =>
+    pipe(
+      received,
+      fold(
+        constFalse,
+        flow(
+          O.fromPredicate(Array.isArray),
+          O.flatMap(accessor),
+          O.filter(predicate),
+          O.isSome
+        ),
+        constFalse
+      )
+    );
+
+/** @internal */
+const applyEqualsRightTupleMatcher =
+  (matcherName: string, accessor: (as: unknown[]) => O.Option<unknown>) =>
+  (received: unknown, expected: unknown): any => {
+    const applyPredicate = pipe(
+      equals(expected),
+      applyPredicateRightTuple(accessor)
+    );
+
+    if (!isEitherOrThese(received)) {
+      return {
+        pass: false,
+        message: () =>
+          [
+            matcherHint(matcherName, 'received', 'expected'),
+            '\n',
+            'Received value is not an Either or These.',
+            `Received: ${printReceived(received)}`,
+          ].join('\n'),
+      };
+    } else if (!isRight(received)) {
+      return {
+        pass: false,
+        message: () =>
+          [
+            matcherHint(matcherName, 'received', 'expected'),
+            '\n',
+            'Received value is not Right.',
+            `Received: ${printReceived(received)}`,
+          ].join('\n'),
+      };
+    } else if (!Array.isArray(received.right) || received.right.length !== 2) {
+      return {
+        pass: false,
+        message: () =>
+          [
+            matcherHint(matcherName, 'received', 'expected'),
+            '\n',
+            'Received value is not a tuple: [result, state].',
+            `Received: ${printReceived(received.right)}`,
+          ].join('\n'),
+      };
+    } else if (!applyPredicate(received)) {
+      return {
+        pass: false,
+        message: () =>
+          [
+            matcherHint(matcherName, 'received', 'expected'),
+            '\n',
+            printDiffOrStringify(
+              expected,
+              O.toNullable(accessor(received.right as any)),
+              'Expected',
+              'Received.right',
+              true
+            ),
+          ].join('\n'),
+      };
+    } else {
+      return {
+        pass: true,
+        message: () =>
+          [
+            matcherHint('.not.' + matcherName, 'received', 'expected'),
+            '\n',
+            `Expected: not ${printExpected(expected)}`,
+          ].join('\n'),
+      };
+    }
+  };
+
+/**
+ * Checks that the received value is a `Right` `Either` or `These` and that its
+ * value is a tuple `[result, state]`. It finally checks that the `result` is
+ * equal to the expected value using Jest's `toEqual()`.
+ *
+ * This is useful when testing the `State` monad or its derivatives.
+ *
+ * ```
+ * describe('toHaveRightValueWithResult', () => {
+ *   it('matches against a right result value', () => {
+ *     expect(E.right([{ foo: 'bar' }, 'some state'])).toHaveRightValueWithResult({
+ *       foo: 'bar',
+ *     });
+ *   });
+ * });
+ * ```
+ *
+ * @category matchers
+ * @since 0.0.5
+ */
+export const toHaveRightValueWithResult = applyEqualsRightTupleMatcher(
+  'toHaveRightValueWithResult',
+  A.head
+);
+
+/**
+ * Checks that the received value is a `Right` `Either` or `These` and that its
+ * value is a tuple `[result, state]`. It finally checks that the `state` is
+ * equal to the expected value using Jest's `toEqual()`.
+ *
+ * This is useful when testing the `State` monad or its derivatives.
+ *
+ * ```
+ * describe('toHaveRightValueWithState', () => {
+ *   it('matches against a right result value', () => {
+ *     expect(E.right([{ foo: 'bar' }, 'some state'])).toHaveRightValueWithState(
+ *       'some state'
+ *     );
+ *   });
+ * });
+ * ```
+ *
+ * @category matchers
+ * @since 0.0.5
+ */
+export const toHaveRightValueWithState = applyEqualsRightTupleMatcher(
+  'toHaveRightValueWithState',
+  A.lookup(1)
+);
+
+/** @internal */
+type Matchers<T = typeof matchers> = {
+  [K in keyof T]: T[K] extends (...args: [any, ...infer R]) => any
+    ? (...args: R) => any
+    : never;
+};
+
+/** @internal */
+type CustomMatchers<R = unknown> = Matchers & {
+  /**
+   * Use `.toHaveRightValueWithResult` to check if a value is an `Either` or
+   * `These`, that it is `Right`, its value is a tuple `[result, state]`, and
+   * that the `result` is equal to an expected value.
+   *
+   * Equality is checked with Jest's `.toEqual()` comparison.
+   */
+  toHaveRightValueWithResult(expected: unknown): R;
+
+  /**
+   * Use `.toHaveRightValueWithResult` to check if a value is an `Either` or
+   * `These`, that it is `Right`, its value is a tuple `[result, state]`, and
+   * that the `state` is equal to an expected value.
+   *
+   * Equality is checked with Jest's `.toEqual()` comparison.
+   */
+  toHaveRightValueWithState(expected: unknown): R;
+};
+
+expect.extend({
+  toHaveRightValueWithResult,
+  toHaveRightValueWithState,
+  ...matchers,
+});
+
+declare module 'expect' {
+  /* eslint-disable-next-line @typescript-eslint/no-empty-interface */
+  interface Matchers<R> extends CustomMatchers<R> {}
+}

--- a/tests/DynamicImport.ts
+++ b/tests/DynamicImport.ts
@@ -1,4 +1,4 @@
-import '@relmify/jest-fp-ts';
+import { describe, it, expect } from '@jest/globals';
 import { pipe } from 'fp-ts/lib/function';
 import * as DI from '../src/DynamicImport';
 import * as RO from 'fp-ts/lib/ReadonlyArray';

--- a/tests/Jest.ts
+++ b/tests/Jest.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from '@jest/globals';
+import { pipe } from 'fp-ts/lib/function';
+import * as TE from 'fp-ts/lib/TaskEither';
+import * as E from 'fp-ts/lib/Either';
+
+import * as mod from '../fixtures/MockableStateReaderTaskEither';
+import { mockStateReaderTaskEither } from '../src/Jest';
+
+describe(mockStateReaderTaskEither, () => {
+  it('can mock on StateReaderTaskEither return values', async () => {
+    const [spy] = mockStateReaderTaskEither(mod, 'testFunction');
+    spy.mockReturnValue(TE.of([10, 'foo']));
+
+    const program = pipe(1, mod.testFunction('some state'));
+    const result = await program();
+
+    expect(E.isRight(result) && result.right).toEqual([10, 'foo']);
+  });
+
+  it('can spy on reader arguments', async () => {
+    const [spy] = mockStateReaderTaskEither(mod, 'testFunction');
+
+    const program = pipe(1, mod.testFunction('some state'));
+    await program();
+
+    expect(spy).toHaveBeenCalledWith(1);
+  });
+
+  it('can spy on state arguments', async () => {
+    const [_, spy] = mockStateReaderTaskEither(mod, 'testFunction');
+
+    const program = pipe(1, mod.testFunction('some state'));
+    await program();
+
+    expect(spy).toHaveBeenCalledWith('some state');
+  });
+});
+
+describe('toHaveRightValueWithResult', () => {
+  it('matches against a right result value', () => {
+    expect(E.right([{ foo: 'bar' }, 'some state'])).toHaveRightValueWithResult({
+      foo: 'bar',
+    });
+  });
+
+  it('fails when result does not match', () => {
+    expect(
+      E.right([{ foo: 'bar' }, 'some state'])
+    ).not.toHaveRightValueWithResult({ foo: 'baz' });
+  });
+
+  it('fails when result is not an Either or These', () => {
+    expect('string').not.toHaveRightValueWithResult({ foo: 'bar' });
+  });
+
+  it('fails when result.right is not a two value tuple', () => {
+    expect(E.right({ foo: 'bar' })).not.toHaveRightValueWithResult({
+      foo: 'bar',
+    });
+  });
+});
+
+describe('toHaveRightValueWithState', () => {
+  it('matches against a right result value', () => {
+    expect(E.right([{ foo: 'bar' }, 'some state'])).toHaveRightValueWithState(
+      'some state'
+    );
+  });
+
+  it('fails when resulting state does not match', () => {
+    expect(
+      E.right([{ foo: 'bar' }, 'not some state'])
+    ).not.toHaveRightValueWithState('some state');
+  });
+
+  it('fails when result is not an Either or These', () => {
+    expect('string').not.toHaveRightValueWithState('some state');
+  });
+
+  it('fails when result.right is not a two value tuple', () => {
+    expect(E.right({ foo: 'bar' })).not.toHaveRightValueWithState('some state');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "moduleResolution": "node",
     "strict": true,
     "declaration": false,
-    "removeComments": true
+    "removeComments": true,
+    "esModuleInterop": true
   },
   "include": ["./src/**/*.ts", "./test/**/*.ts"]
 }


### PR DESCRIPTION
This module provides a place for utility functions and types that reduce the boiler plate when writing tests with fp-ts types. This adds:

- `mockStateReaderTaskEither` which provides an easier way to create mocks and spies to check that the Reader and TaskEither parts get called correctly.

- Matches `toHaveRightValueWithResult` and `toHaveRightValueWithState` which remove the repetition involved with checking that these StateReaderTaskEither functions return the right result or state.