### PR TITLE
FIX Stream.separate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@relmify/jest-fp-ts": "^2.1.1",
+        "async-mutex": "^0.4.0",
         "fp-ts-contrib": "^0.1.29",
         "fp-ts-std": "^0.17.1",
         "jest-matcher-utils": "^29.6.1",
@@ -2725,6 +2726,14 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
+    },
+    "node_modules/async-mutex": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
+      "integrity": "sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -9235,8 +9244,7 @@
     "node_modules/tslib": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
-      "dev": true
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arena-fp-ts",
   "homepage": "https://github.com/arenadotio/arena-fp-ts",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "main": "dist/index.js",
   "license": "MIT",
   "repository": {
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@relmify/jest-fp-ts": "^2.1.1",
+    "async-mutex": "^0.4.0",
     "fp-ts-contrib": "^0.1.29",
     "fp-ts-std": "^0.17.1",
     "jest-matcher-utils": "^29.6.1",


### PR DESCRIPTION
This function was previously implemented incorrectly because it tried to read from the same iterable multiple times. The act of reading the iterable is not a pure process and can't be assumed to have no side effects.

This re implements separate to create two new streams which both pull from the same source as needed.

This function is going to let us stream data through various steps in a lambda and still end up with a collection of which elements succeeded and which ones failed.